### PR TITLE
fix: remove producthunt link on twitter share

### DIFF
--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -14,7 +14,7 @@
 
 	$: username = $page.params.username;
 	$: shareTwitter = encodeURI(
-		`We are all the makers of @Appwrite! Open source allows all of us to collaborate and build better software together!\n\nJoin us in celebrating Appwrite 1.0 on Product Hunt 😺\nhttps://appwrite.io/product-hunt\n\nYou can check out my maker card here: https://makers.appwrite.io/${username}`
+		`We are all the makers of @Appwrite! Open source allows all of us to collaborate and build better software together!\n\nYou can check out my maker card here: https://makers.appwrite.io/${username}`
 	);
 
 	$: embed = `<a href="${globalThis.location?.href}">


### PR DESCRIPTION
## What does this PR do?

- removes PH link from twitter share
